### PR TITLE
use binary/octet-stream

### DIFF
--- a/inflight.go
+++ b/inflight.go
@@ -90,7 +90,7 @@ func (i *Inflight) tryWriteToS3(data io.ReadSeeker, object string) func() error 
 			Bucket:      aws.String(bucket),
 			Key:         aws.String(filepath.Join(keyPath, object)),
 			Body:        data,
-			ContentType: aws.String("application/json"),
+			ContentType: aws.String("binary/octet-stream"),
 		})
 
 		_, err := req.Send()


### PR DESCRIPTION
Mime-Type was being set to JSON even though the library doesn't really know what sort of data is being sent to s3. Better to set as a binary Mime-Type